### PR TITLE
Don't purge casper. (LP: #1558990)

### DIFF
--- a/late/scripts/oem_config.sh
+++ b/late/scripts/oem_config.sh
@@ -60,7 +60,6 @@ elif [ "$1" = "late" ]; then
     fi
     umount /cdrom
     /usr/share/dell/scripts/pool.sh cleanup
-    apt-get purge --yes casper
 else
     echo "Unknown arguments $1 $2"
 fi


### PR DESCRIPTION
When creating the recovery media ISO, it needs casper.
If we purge casper, the recovery media ISO will malfunction.