### PR TITLE
Keep dell-recovery-casper not purged by ubiquity. (LP: #1558990)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,8 @@ Description: Dell Recovery Media Creation Package
 
 Package: dell-recovery-casper
 Architecture: all
-Depends: dell-recovery, casper, ubiquity, ${misc:Depends}
+Depends: dell-recovery, casper, ${misc:Depends}
+Recommends: ubiquity
 Description: Dell Recovery Casper Hooks
  This package provides hooks to allow the dell-recovery
  bootstrap to run directly from casper without any other

--- a/debian/dell-recovery-casper.prerm
+++ b/debian/dell-recovery-casper.prerm
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+: # Do nothing here
+
+#DEBHELPER#


### PR DESCRIPTION
https://bugs.launchpad.net/bugs/1552621 will remove ubiquity so we recommend it instead of depending on it.
Ubiquity will check dell-recovery-casper.prerm so we prepare an empty script for it.