### PR TITLE
Use oem-config-prepare instead of hacking systemd target.

### DIFF
--- a/late/chroot_scripts/05-enable-oem-config.sh
+++ b/late/chroot_scripts/05-enable-oem-config.sh
@@ -25,6 +25,6 @@
 
 . /usr/share/dell/scripts/fifuncs ""
 
-IFHALT "Enable oem-config systemd target"
-/bin/systemctl set-default oem-config.target
+IFHALT "Enable oem-config"
+oem-config-prepare --quiet
 IFHALT "Done with enable oem config"


### PR DESCRIPTION
There are some changes by https://bugs.launchpad.net/bugs/1552621.
We should use `oem-config-prepare --quiet` instead of hacking systemd target.