### PR TITLE
Fix the problem that EFI boot configuration cannot be persistent in VirtualBox VM.

### DIFF
--- a/late/chroot_scripts/02-grub.sh
+++ b/late/chroot_scripts/02-grub.sh
@@ -27,4 +27,8 @@
 
 IFHALT "Rerun GRUB update"
 /usr/sbin/update-grub
+if [ -d /sys/firmware/efi ] && \
+	grep innotek /sys/class/dmi/id/bios_vendor /sys/class/dmi/id/sys_vendor; then
+	echo 'fs0:\efi\ubuntu\shimx64.efi' > /boot/efi/startup.nsh
+fi
 IFHALT "Done with GRUB update"


### PR DESCRIPTION
It is annoying to rebuild or manually input the EFI boot entry after every shutdown.