### PR TITLE
Only search for the prefix 'String 2:' and lowercase the BIOS ID.

### DIFF
--- a/late/chroot_scripts/03-ubuntu-drivers.sh
+++ b/late/chroot_scripts/03-ubuntu-drivers.sh
@@ -11,12 +11,11 @@ for i in `ubuntu-drivers list`; do
 done
 
 #install meta package based upon BIOS ID
-BIOS_ID=$(dmidecode -t 11 | sed '/String 2/!d; s,.*String 2: 1\[,,; s,\],,')
+BIOS_ID=$(dmidecode -t 11 | sed '/String 2:/!d; s,.*String 2: 1\[,,; s,\],,' | tr A-Z a-z)
 PACKAGE=dell-$BIOS_ID-meta
-    if ! dpkg-query -W $PACKAGE  >/dev/null 2>&1; then
-        apt-get install --yes $PACKAGE || true
-    fi
-
+if ! dpkg-query -W $PACKAGE >/dev/null 2>&1; then
+    apt-get install --yes $PACKAGE || true
+fi
 
 rm /etc/apt/apt.conf.d/99disable_authentication
 IFHALT "Done with ubuntu-drivers autoinstall"


### PR DESCRIPTION
This patch contains three changes.

The first is to only search for the prefix 'String 2:' or it will also find 'String 20:'.
The second is to lowercase BIOS ID because Debian package doesn't allow uppercase as its package name.
The third is to fix the indent.