### PR TITLE
Include post-rts-gfx.cfg and post-rts-wlan.cfg on user launched recovery.

### DIFF
--- a/grub/99_dell_recovery
+++ b/grub/99_dell_recovery
@@ -11,6 +11,12 @@ menuentry "#RECOVERY_TEXT#" {
         else
             set options="boot=casper automatic-ubiquity noprompt quiet splash nomodeset"
         fi
+        if [ -s /factory/post-rts-gfx.cfg ]; then
+            source /factory/post-rts-gfx.cfg
+        fi
+        if [ -s /factory/post-rts-wlan.cfg ]; then
+            source /factory/post-rts-wlan.cfg
+        fi
         #Support starting from a loopback mount (Only support ubuntu.iso for filename)
         if [ -f /ubuntu.iso ]; then
             loopback loop /ubuntu.iso


### PR DESCRIPTION
If there are any kernel parameters or other configs were set in the post-rts-gfx.cfg or post-rts-wlan.cfg for factory process, those changes are also required by user manually launched dell-recovery.